### PR TITLE
feat!: reduce image size and improve dep caching on img build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 *
 !src
 !.editorconfig
-src/*/bin
-src/*/obj
+src/**/bin
+src/**/obj

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,20 +96,8 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           push: false
           target: test
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Get platforms to build
-        id: platforms
-        run: |
-          if [ "$IS_PULL_REQUEST" == "true" ]; then
-            echo "::set-output name=platforms::linux/amd64"
-          else
-            echo "::set-output name=platforms::linux/amd64,linux/arm64,linux/arm/v7"
-          fi
-        env:
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3
@@ -120,7 +108,6 @@ jobs:
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           load: ${{ github.event_name == 'pull_request' }}
-          platforms: ${{ steps.platforms.outputs.platforms }}
       - name: List images
         id: list_images
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,52 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim-amd64 AS build
-WORKDIR /build
-COPY src/FhirServerExporter/FhirServerExporter.csproj .
-RUN dotnet restore
+# syntax=docker/dockerfile:1.3
+FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim-amd64 as build
+WORKDIR "/build"
+COPY src/FhirServerExporter.Tests/FhirServerExporter.Tests.csproj ./src/FhirServerExporter.Tests/
+COPY src/FhirServerExporter/FhirServerExporter.csproj ./src/FhirServerExporter/
+
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore src/FhirServerExporter/FhirServerExporter.csproj \
+    --runtime linux-x64
+
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet restore src/FhirServerExporter.Tests/FhirServerExporter.Tests.csproj\
+    --runtime linux-x64
+
 COPY . .
 
-RUN dotnet publish \
-    -c Release \
-    -o /build/publish \
-    /p:UseAppHost=false \
-    src/FhirServerExporter/FhirServerExporter.csproj
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet build src/FhirServerExporter/FhirServerExporter.csproj \
+    --no-restore \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained true \
+    --framework net6.0
+
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet publish src/FhirServerExporter/FhirServerExporter.csproj \
+    --no-restore \
+    --no-build \
+    --configuration Release \
+    --runtime linux-x64 \
+    --self-contained true \
+    --framework net6.0 \
+    -o /build/publish
 
 FROM build AS test
 WORKDIR /build/src/FhirServerExporter.Tests
-RUN dotnet test -p:CollectCoverage=true
+RUN --mount=type=cache,id=nuget,target=/root/.nuget/packages \
+    dotnet test FhirServerExporter.Tests.csproj \
+    --no-restore \
+    -p:CollectCoverage=true
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim
+FROM gcr.io/distroless/cc-debian11:nonroot@sha256:c2e1b5b0c64e3a44638e79246130d480ff09645d543d27e82ffd46a6e78a3ce3
 WORKDIR /opt/fhir-server-exporter
-COPY --from=build /build/publish .
-
 ENV DOTNET_ENVIRONMENT="Production" \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
-EXPOSE 9797
+EXPOSE 9797/tcp
 USER 65532
-ENTRYPOINT ["dotnet", "/opt/fhir-server-exporter/FhirServerExporter.dll"]
+
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /build/publish .
+
+ENTRYPOINT ["/opt/fhir-server-exporter/FhirServerExporter"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ FHIR server resource count exporter for Prometheus.
 ```sh
 docker run --rm -it \
     -p 9797:9797 \
-    -e FHIRSERVERURL="https://hapi.fhir.org/baseR4" \
+    -e FHIRSERVERURL="http://hapi.fhir.org/baseR4" \
     -e FETCHINTERVALSECONDS=60 \
     ghcr.io/chgl/fhir-server-exporter:latest
 ```
@@ -61,7 +61,7 @@ Create a file called `queries.yaml` and place it in the application's main direc
 
 ```sh
 docker run --rm -it \
-   -e FHIRSERVERURL="https://hapi.fhir.org/baseR4" \
+   -e FHIRSERVERURL="http://hapi.fhir.org/baseR4" \
    -p 9797:9797 \
    -v $PWD/src/FhirServerExporter/queries.yaml:/opt/fhir-server-exporter/queries.yaml:ro \
    ghcr.io/chgl/fhir-server-exporter:latest
@@ -100,6 +100,8 @@ so if you've specified both a basic auth username and password and an oauth toke
 
 ## Development
 
+### Using Docker Compose
+
 1. Start an empty HAPI FHIR server exposed on port 8282 and a pre-configured Prometheus instance on port 9090:
 
    ```sh
@@ -114,6 +116,20 @@ so if you've specified both a basic auth username and password and an oauth toke
    ```
 
 1. Access the exposed metrics at <http://localhost:9797/metrics>
+
+### On Kubernetes using Skaffold+Kustomize
+
+1. create a local testing cluster
+
+   ```sh
+   kind create cluster
+   ```
+
+1. build and deploy container in development mode
+
+   ```sh
+   skaffold dev
+   ```
 
 ### Build and run container image locally
 

--- a/hack/docker-compose.dev.yml
+++ b/hack/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   prometheus:
     image: quay.io/prometheus/prometheus:v2.35.0
@@ -9,7 +7,9 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
 
   fhir-server:
-    image: docker.io/hapiproject/hapi:v5.6.0-distroless
+    image: docker.io/hapiproject/hapi:v5.7.0
+    environment:
+      HAPI_FHIR_MDM_ENABLED: "false"
     ports:
       - "127.0.0.1:8082:8080"
 

--- a/src/FhirServerExporter/FhirServerExporter.csproj
+++ b/src/FhirServerExporter/FhirServerExporter.csproj
@@ -5,6 +5,11 @@
     <UserSecretsId>dotnet-FhirServerExporter-51CE8CEB-7E96-4CF2-8F16-71D416CB7867</UserSecretsId>
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <!-- Doesn't yet work due to  error IL2026: Using member 'Microsoft.Extensions.Configuration.ConfigurationBinder.GetValue<string> -->
+    <PublishTrimmed>false</PublishTrimmed>
+    <PublishReadyToRunShowWarnings>false</PublishReadyToRunShowWarnings>
     <WarningsAsErrors />
   </PropertyGroup>
 


### PR DESCRIPTION
BREAKING CHANGE: no longer build ARM versions of the container image.

Reduces uncompressed image size from 219MB to 136MB by using distroless
and publishing ready-to-run and as a single file.